### PR TITLE
Feat: Ability to change the doctype header and html tag to

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ piecemeal and prefix types with the package name. Note that the traits `Html` an
 use build_html::{self, Html, HtmlContainer};
 
 let page = build_html::HtmlPage::new()
+    .doctype_html5() // Change the doctype to use HTML5
+    .doctype_xhtml() // Change the doctype to  XHTML 1.0
+    .html_xml() // Change the `<html>` tag to `<html xmlns="http://www.w3.org/1999/xhtml">`
     .with_paragraph("Some Text")
     .to_html_string();
 ```

--- a/src/html_page/constants.rs
+++ b/src/html_page/constants.rs
@@ -1,0 +1,8 @@
+/// The HTML tag with XML attribute, which is very useful for HTML emails.
+pub const HTML_XML: &str = "<html xmlns=\"http://www.w3.org/1999/xhtml\">";
+/// The doctype for legacy XHTML header. This is still common in HTML emails for backwards compatibility with different email clients
+pub const XHTML_1_DOT_0: &str = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">";
+/// The doctype for newest version of HTML which is HTML5
+pub const HTML5: &str = "<!DOCTYPE html>";
+/// Plain HTML tag
+pub const HTML_PLAIN_TAG: &str = "<html>";

--- a/src/html_page/mod.rs
+++ b/src/html_page/mod.rs
@@ -4,7 +4,9 @@ use crate::attributes::Attributes;
 use crate::html_container::HtmlContainer;
 use crate::Html;
 
+mod constants;
 mod header_content;
+pub use constants::*;
 
 /// This struct represents an entire page of HTML which can built up by chaining addition methods.
 ///
@@ -26,6 +28,8 @@ mod header_content;
 /// ```
 #[derive(Debug)]
 pub struct HtmlPage {
+    doctype: String,
+    html: String,
     head: String,
     body: String,
 }
@@ -33,8 +37,8 @@ pub struct HtmlPage {
 impl Html for HtmlPage {
     fn to_html_string(&self) -> String {
         format!(
-            "<!DOCTYPE html><html><head>{}</head><body>{}</body></html>",
-            self.head, self.body
+            "{}{}<head>{}</head><body>{}</body></html>",
+            self.doctype, self.html, self.head, self.body
         )
     }
 }
@@ -48,17 +52,54 @@ impl HtmlContainer for HtmlPage {
 
 impl Default for HtmlPage {
     fn default() -> Self {
-        HtmlPage::new()
+        HtmlPage {
+            doctype: HTML5.to_owned(),
+            html: HTML_PLAIN_TAG.to_owned(),
+            head: String::new(),
+            body: String::new(),
+        }
     }
 }
 
 impl HtmlPage {
     /// Creates a new HTML page with no content
     pub fn new() -> Self {
-        HtmlPage {
-            head: String::new(),
-            body: String::new(),
-        }
+        HtmlPage::default()
+    }
+
+    /// Change the doctype to something custom
+    pub fn custom_doctype(&mut self, doctype: &str) -> &mut Self {
+        self.doctype = doctype.to_owned();
+
+        self
+    }
+
+    /// Change the `<html>` tag to something with custom attributes
+    pub fn custom_html_tag(&mut self, html_tag_attribute: &str) -> &mut Self {
+        self.html = html_tag_attribute.to_owned();
+
+        self
+    }
+
+    /// Convert doctype to HTML5
+    pub fn doctype_html5(&mut self) -> &mut Self {
+        self.doctype = HTML5.to_owned();
+
+        self
+    }
+
+    /// Convert doctype to XHTML which is very useful for legacy compatibility for example with HTML email clients
+    pub fn doctype_xhtml(&mut self) -> &mut Self {
+        self.doctype = XHTML_1_DOT_0.to_owned();
+
+        self
+    }
+
+    /// Convert `<html>` tag to have XML attribute which is very useful for legacy compatibility for example with HTML email clients
+    pub fn html_xml(&mut self) -> &mut Self {
+        self.html = HTML_XML.to_owned();
+
+        self
     }
 
     /// Helper function similar to [`HtmlContainer::add_html`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod table;
 // Exports for the `use build_html::*` syntax
 pub use self::container::{Container, ContainerType};
 pub use self::html_container::HtmlContainer;
-pub use self::html_page::HtmlPage;
+pub use self::html_page::*;
 pub use self::table::Table;
 
 /// An element that can be converted to an HTML string


### PR DESCRIPTION
This pull request allows the changing of the doctype tag to something else like XHTML 1.0 which is can be use for compatibility with legacy email clients.

The <html> tag can also have attributes for legacy compatibility