### PR TITLE
Add support for HTML versions

### DIFF
--- a/src/html_page/mod.rs
+++ b/src/html_page/mod.rs
@@ -5,8 +5,11 @@ use crate::html_container::HtmlContainer;
 use crate::Html;
 
 mod header_content;
+mod version;
 
-/// This struct represents an entire page of HTML which can built up by chaining addition methods.
+pub use version::HtmlVersion;
+
+/// An entire page of HTML which can built up by chaining addition methods.
 ///
 /// To convert an `HtmlPage` to a [`String`] which can be sent back to a client, use the
 /// [`Html::to_html_string()`] method
@@ -24,8 +27,9 @@ mod header_content;
 ///     "<body><h1>Header Text</h1></body></html>"
 /// ));
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct HtmlPage {
+    version: version::HtmlVersion,
     head: String,
     body: String,
 }
@@ -33,8 +37,11 @@ pub struct HtmlPage {
 impl Html for HtmlPage {
     fn to_html_string(&self) -> String {
         format!(
-            "<!DOCTYPE html><html><head>{}</head><body>{}</body></html>",
-            self.head, self.body
+            "{}<html{}><head>{}</head><body>{}</body></html>",
+            self.version.doctype(),
+            self.version.html_attrs(),
+            self.head,
+            self.body,
         )
     }
 }
@@ -46,16 +53,29 @@ impl HtmlContainer for HtmlPage {
     }
 }
 
-impl Default for HtmlPage {
-    fn default() -> Self {
-        HtmlPage::new()
-    }
-}
-
 impl HtmlPage {
     /// Creates a new HTML page with no content
     pub fn new() -> Self {
+        Self::with_version(HtmlVersion::HTML5)
+    }
+
+    /// Create a new HTML page with the specified version.
+    ///
+    /// # Example
+    /// ```
+    /// # use build_html::{Html, HtmlPage, HtmlVersion};
+    /// assert_eq!(
+    ///     HtmlPage::with_version(HtmlVersion::HTML4).to_html_string(),
+    ///     concat!(
+    ///         r#"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "#,
+    ///         r#""http://www.w3.org/TR/HTML4/loose.dtd">"#,
+    ///         "<html><head></head><body></body></html>",
+    ///     ),
+    /// )
+    /// ```
+    pub fn with_version(version: HtmlVersion) -> Self {
         HtmlPage {
+            version,
             head: String::new(),
             body: String::new(),
         }

--- a/src/html_page/version.rs
+++ b/src/html_page/version.rs
@@ -1,0 +1,83 @@
+//! This module contains definitions of the various HTML versions
+
+use crate::attributes::Attributes;
+
+/// Versions of the HTML (or XHTML) standard
+///
+/// These can be used to change the doctype and apply attributes to an [`HtmlPage`](crate::HtmlPage).
+///
+/// # Example
+/// ```
+/// # use build_html::{Html, HtmlPage, HtmlVersion};
+/// assert_eq!(
+///     HtmlPage::with_version(HtmlVersion::HTML5).to_html_string(),
+///     "<!DOCTYPE html><html><head></head><body></body></html>"
+/// );
+///
+/// assert_eq!(
+///     HtmlPage::with_version(HtmlVersion::XHTML1_0).to_html_string(),
+///     concat!(
+///         r#"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "#,
+///         r#""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">"#,
+///         r#"<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>"#,
+///     ),
+/// )
+/// ```
+///
+/// # Compliance With HTML Standards
+/// Please note that while we allow users to specify the version of the HTML standard their page
+/// is written in, this library *does not* and *will not* check whether your page is actually valid
+/// in that standard. Our feature set is targeting development in HTML5 and it is possible that
+/// some tags or attributes may not be valid in older HTML versions. You are responsible for
+/// knowing which subset of the provided features are valid for your chosen version. Use this
+/// feature at your own risk.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub enum HtmlVersion {
+    /// HTML 5. The current and preferred version of the HTML standard.
+    #[default]
+    HTML5,
+    /// Legacy HTML 4.01. Potentially useful for supporting old browsers.
+    HTML4,
+    /// Legacy XHTML 1.0. This is still common in HTML emails for backwards
+    /// compatibility with different email clients.
+    XHTML1_0,
+    /// Legacy XHTML 1.1.
+    XHTML1_1,
+}
+
+impl HtmlVersion {
+    /// Return the DOCTYPE (DTD) that corresponds to this version of the HTML standard
+    pub fn doctype(&self) -> &'static str {
+        match self {
+            Self::HTML5 => "<!DOCTYPE html>",
+            Self::HTML4 => {
+                r#"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/HTML4/loose.dtd">"#
+            }
+            Self::XHTML1_0 => {
+                r#"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">"#
+            }
+            Self::XHTML1_1 => {
+                r#"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">"#
+            }
+        }
+    }
+
+    /// Return the set of attributes that should be applied to the `HtmlPage`'s opening HTML tag
+    pub fn html_attrs(&self) -> Attributes {
+        match self {
+            Self::XHTML1_0 => Attributes::from([("xmlns", "http://www.w3.org/1999/xhtml")]),
+            Self::XHTML1_1 => Attributes::from([
+                ("xmlns", "http://www.w3.org/1999/xhtml"),
+                ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"),
+                (
+                    "xsi:schemaLocation",
+                    "http://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd",
+                ),
+                ("xml:lang", "en"),
+            ]),
+
+            _ => Attributes::default(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod table;
 // Exports for the `use build_html::*` syntax
 pub use self::container::{Container, ContainerType};
 pub use self::html_container::HtmlContainer;
-pub use self::html_page::HtmlPage;
+pub use self::html_page::{HtmlPage, HtmlVersion};
 pub use self::table::Table;
 
 /// An element that can be converted to an HTML string


### PR DESCRIPTION
Add support for multiple versions of HTML. Compared to #4, this implementation is a bit more flexible and should allow us to add more versions over time if necessary. I think that having the user set their version once when the page is created is more elegant than having to coordinate between setting the doctype and the attributes for the `html` tag separately. 